### PR TITLE
Adds default renovate configuration

### DIFF
--- a/renovate-android.json
+++ b/renovate-android.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "group:all",
+    ":dependencyDashboard",
+    "schedule:daily",
+    ":automergeStableNonMajor"
+  ],
+  "onboarding": false,
+  "requireConfig": "optional",
+
+  "commitMessageExtra": "{{{currentValue}}} to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "androidx.compose.compiler:compiler"
+      ],
+      "groupName": "kotlin"
+    },
+    {
+      "matchPackagePatterns": [
+        "org.jetbrains.kotlin.*"
+      ],
+      "groupName": "kotlin"
+    },
+    {
+      "matchPackagePatterns": [
+        "com.google.devtools.ksp"
+      ],
+      "groupName": "kotlin"
+    }
+  ]
+}

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -2,5 +2,8 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>android/.github:renovate-android"
+    ],
+    "baseBranches": [
+        "main",
     ]
 }

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>android/.github:renovate-android"
+    ]
+}


### PR DESCRIPTION
This is a test because the documentation contradicts itself (or I misunderstood them).

The Mend Renovate app makes this a hosted environment, so we can't use env variables to set global configuration options.

`renovate-config` is supposed to be picked up by Renovate as default config for onboarding PRs as stated in https://docs.renovatebot.com/config-overview/#onboarding-config

However, https://docs.renovatebot.com/mend-hosted/hosted-apps-config/#inherited-config says that only the "android/renovate-config" repository works in hosted apps. Let's see.